### PR TITLE
Tidy up readme following move to new repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Building the website
 
 2. Clone this repository.
 
+   ```
+   git clone https://github.com/OpenCMISS/website
+   ```
+
 3. Enter the repository folder. Download OpenCMISS documentation (https://github.com/OpenCMISS/documentation) and place it into the website repository.
 
    ```
@@ -45,8 +49,7 @@ Building the website
    Run the following. Replace [URL] with the root of where this site will be hosted, e.g. "next.opencmiss.org". This is used for generating a sitemap for the website. 
 
    ```
-   cd _web
-   export SITE_URL=[URL];make
+   SITE_URL=[URL] make
    ```
    NOTE - The first time the script is run, you may run into this prompt:
    
@@ -65,4 +68,4 @@ Building the website
    This is because during the API documentation build, we need to fetch the Zinc library source from Physiome Project's SVN server. The SVN server uses an SSL certificate that isn't recognised. Please verify the certificate, and if it's correct, accept it Permanently to store it.
 
 
-5. The built website is now available in `_web/build/dist/`. Serve with your favourite web server.
+5. The built website is now available in `build/dist/`. Serve with your favourite web server.


### PR DESCRIPTION
Suggestions to tidy up the readme, assuming the `_web` folder is a hangover from the previous repository?