### PR TITLE
Ensure echo command is not printed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ debug: summary clean deps apidoc
 
 summary:
 ifeq ($(APIDOC),no)
-	echo "API Documentation: disabled (API docs will not be included in the build. Only use this if you are generating the site for testing purposes.)"
+	@echo "API Documentation: disabled (API docs will not be included in the build. Only use this if you are generating the site for testing purposes.)"
 endif
 
 apidoc:


### PR DESCRIPTION
It is good to make sure `echo` commands themselves are not printed to the terminal to avoid doubling up messages.