### PR TITLE
Fix generation of API documentation into correct location.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ endif
 apidoc:
 ifeq ($(APIDOC),yes)
 	make -C apidoc
-	cp -r apidoc/build/apidoc extgen
+	mkdir extgen/documentation
+	cp -r apidoc/build/apidoc extgen/documentation
 endif
 
 deps :

--- a/apidoc/Makefile
+++ b/apidoc/Makefile
@@ -4,8 +4,8 @@ html: clean
 	cp -r LibZincDoxygen/libzinc_doxgen_script .working
 	cd .working; python api_2_api++_doc.py
 	cd .working/libzinc_doxgen_script; doxygen cpp_comments.doxygen
-	mkdir -p build/documentation/apidoc/zinc/latest/
-	cp -r .working/libzinc_doxgen_script/libzinc_dox_output/html/* build/documentation/apidoc/zinc/latest
+	mkdir -p build/apidoc/zinc/latest/
+	cp -r .working/libzinc_doxgen_script/libzinc_dox_output/html/* build/apidoc/zinc/latest
 
 clean:
 	rm -rf .working


### PR DESCRIPTION
Generation can occur in the original location, the final placement should be in the documentation directory.