### PR TITLE
update zinc reference to track the most up-to-date branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "apidoc/zinc"]
 	path = apidoc/zinc
 	url = https://github.com/OpenCMISS/zinc
-	branch = devel
+	branch = develop
 [submodule "apidoc/LibZincDoxygen"]
 	path = apidoc/LibZincDoxygen
 	url = https://github.com/OpenCMISS-Dependencies/LibZincDoxygen


### PR DESCRIPTION
This update should address #57. Buildbot build won't be successful until the VM is upgraded for #55 though. 