### PR TITLE
Correct https detection for Google CSE

### DIFF
--- a/app/scripts/search.js
+++ b/app/scripts/search.js
@@ -31,7 +31,7 @@
 	var cx = '008007135417019367495:caxgodc2wem';
 	var gcse = document.createElement('script'); gcse.type = 'text/javascript';
 	gcse.async = true;
-	gcse.src = (document.location.protocol == 'https' ? 'https:' : 'http:') +
+	gcse.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') +
 		'//cse.google.com/cse.js?cx=' + cx;
 	var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(gcse, s);
 


### PR DESCRIPTION
This corrects the protocol detection for Google Custom Search Engine now that the site has (finally) got an SSL certificate.