### PR TITLE
Update Google tag for Google analytics to GA-4

### DIFF
--- a/app/partials/common.jinja
+++ b/app/partials/common.jinja
@@ -107,18 +107,15 @@
 		{% block scripts %}
 		{% endblock %}
 		{% if SITEENV == "release" %}
+		
+		<!-- Google tag (gtag.js) -->
+		<script async src="https://www.googletagmanager.com/gtag/js?id=G-L9G3ZSPNGN"></script>
 		<script>
+		  window.dataLayer = window.dataLayer || [];
+		  function gtag(){dataLayer.push(arguments);}
+		  gtag('js', new Date());
 
-			(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-			(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new
-			Date();a=s.createElement(o),
-
-			m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-
-			})(window,document,'script','https://www.google-analytics.com/analytics.js','analytics');
-			analytics('create', 'UA-78703975-1', 'auto');
-			analytics('send', 'pageview');
-			analytics('set','anonymizeIp',true);
+		  gtag('config', 'G-L9G3ZSPNGN');
 		</script>
 		{% endif %}
 


### PR DESCRIPTION
Update Google tag for Google analytics to GA-4. Must be done by the end of June 2023.